### PR TITLE
Modernize blog with minimal design and dark/light mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.bundle
+.claude
+.sass-cache
+_site
+vendor
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.7
+
+WORKDIR /site
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential git libssl-dev pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN gem install bundler:2.4.22
+
+COPY Gemfile Gemfile.lock jekyll-theme-cayman-blog.gemspec ./
+COPY . .
+
+RUN bundle install
+
+EXPOSE 4000
+
+CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0", "--port", "4000", "--livereload"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
+gem 'jekyll-seo-tag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,15 +37,19 @@ GEM
       terminal-table (~> 1.8)
     jekyll-sass-converter (2.0.1)
       sassc (> 2.0.1, < 3.0)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.1.0)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.2.0)
+    listen (3.10.0)
+      logger
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -65,7 +69,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  jekyll-seo-tag
   jekyll-theme-cayman-blog!
 
 BUNDLED WITH
-   1.16.0
+   2.4.22

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: Chaitya Shah's Blog
+title: Chaitya Shah
 description: CTO & Co-founder at Kyma Lifestyle. Writing about agentic systems, engineering, and building in the age of AI.
 show_downloads: false
 

--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -1,39 +1,86 @@
 <header class="site-header" role="banner">
-
   <div class="wrapper">
-    {% assign default_paths = site.pages | map: "path" %}
-    {% assign page_paths = site.header_pages | default: default_paths %}
-
-
     <a class="site-title" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
-  
 
-    {% if page_paths %}
-      <nav class="site-nav">
-        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-        <label for="nav-trigger">
-          <span class="menu-icon">
-            <svg viewBox="0 0 18 15" width="18px" height="15px">
-              <path fill="#424242" d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.031C17.335,0,18,0.665,18,1.484L18,1.484z"/>
-              <path fill="#424242" d="M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0c0-0.82,0.665-1.484,1.484-1.484 h15.031C17.335,6.031,18,6.696,18,7.516L18,7.516z"/>
-              <path fill="#424242" d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,13.516z"/>
-            </svg>
-          </span>
-        </label>
+    <nav class="site-nav">
+      {% assign default_paths = site.pages | map: "path" %}
+      {% assign page_paths = site.header_pages | default: default_paths %}
 
-        <div class="trigger">
-          {% for path in page_paths %}
-            {% assign my_page = site.pages | where: "path", path | first %}
-            {% if my_page.title %}
-              {% if my_page.title contains "404" %}
-              {% else %}
-                <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
-              {% endif %}
+      <div class="nav-links">
+        {% for path in page_paths %}
+          {% assign my_page = site.pages | where: "path", path | first %}
+          {% if my_page.title %}
+            {% if my_page.title contains "404" %}
+            {% else %}
+              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
             {% endif %}
-          {% endfor %}
-            <a class="page-link" href="https://twitter.com/{{ site.twitter.username }}">@{{site.twitter.username | capitalize}}</a>
-        </div>
-      </nav>
-    {% endif %}
+          {% endif %}
+        {% endfor %}
+      </div>
+
+      <div class="nav-icons">
+        <!-- GitHub -->
+        <a href="{{ site.github.owner_url }}" class="social-icon" aria-label="GitHub" title="GitHub">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        </a>
+
+        <!-- Twitter -->
+        <a href="https://twitter.com/{{ site.twitter.username }}" class="social-icon" aria-label="Twitter" title="Twitter">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+        </a>
+
+        <!-- LinkedIn -->
+        <a href="https://www.linkedin.com/in/chaitya62/" class="social-icon" aria-label="LinkedIn" title="LinkedIn">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+        </a>
+
+        <!-- Theme toggle -->
+        <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"/></svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"/></svg>
+        </button>
+      </div>
+
+      <!-- Mobile hamburger -->
+      <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+      <label for="nav-trigger" class="menu-icon-label">
+        <span class="menu-icon">
+          <svg viewBox="0 0 18 15" width="18px" height="15px">
+            <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.031C17.335,0,18,0.665,18,1.484L18,1.484z"/>
+            <path d="M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0c0-0.82,0.665-1.484,1.484-1.484 h15.031C17.335,6.031,18,6.696,18,7.516L18,7.516z"/>
+            <path d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,13.516z"/>
+          </svg>
+        </span>
+      </label>
+
+      <div class="mobile-menu">
+        {% for path in page_paths %}
+          {% assign my_page = site.pages | where: "path", path | first %}
+          {% if my_page.title %}
+            {% if my_page.title contains "404" %}
+            {% else %}
+              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </nav>
   </div>
 </header>
+
+<script>
+(function() {
+  var toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+  toggle.addEventListener('click', function() {
+    var html = document.documentElement;
+    if (html.classList.contains('dark')) {
+      html.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    } else {
+      html.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    }
+  });
+})();
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,19 +3,16 @@
 
   <head>
 
-    <!-- Non social metatags -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <meta name="theme-color" content="#157878">
+    <meta name="theme-color" content="#ffffff">
 
     {% if page.title %}
       {% assign page-title = page.title | escape %}
     {% else %}
       {% assign page-title = site.title | escape %}
     {% endif %}
-
-    
 
     <title>{{ page-title }}</title>
 
@@ -34,106 +31,74 @@
     <link rel="shortcut icon" href="{{ site.url }}/favicon.ico">
     <meta name="robots" content="noarchive">
 
-    <!-- <link rel="alternate" media="only screen and (max-width: 640px)" href="">
-    <link rel="alternate" media="handheld" href=""> -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+
+    <script>
+      (function() {
+        var theme = localStorage.getItem('theme');
+        if (theme === 'dark') {
+          document.documentElement.classList.add('dark');
+        } else if (theme === 'light') {
+          document.documentElement.classList.remove('dark');
+        } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
   <body>
 
     {% include site-header.html %}
 
-    {% if page.layout == 'home' %}
-      {% assign page-tagline = site.description | default: site.github.project_tagline | escape %}
-    {% endif %}
     {% if page.layout == 'page' %}
       {% assign page-tagline = page.tagline | escape %}
     {% endif %}
     {% if page.layout == 'post' %}
-      {% assign page-tagline = page.tagline | escape  %}
+      {% assign page-tagline = page.tagline | escape %}
     {% endif %}
 
+    {% unless page.layout == 'home' %}
     <section class="page-header">
       <h1 class="project-name">{{ page-title }}</h1>
-      <h2 class="project-tagline">{{ page-tagline }}</h2>
-      {% if page.layout == 'home' and site.github.is_project_page %}
-          <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
-        {% if site.show_downloads %}
-          <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>
-          <a href="{{ site.github.tar_url }}" class="btn">Download .tar.gz</a>
-        {% endif %}
+      {% if page-tagline and page-tagline != '' %}
+        <p class="project-tagline">{{ page-tagline }}</p>
       {% endif %}
-      <!-- Post tagline -->
       {% if page.layout == 'post' %}
-        <h2 class="project-date">
+        <p class="project-date">
         <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
           {% assign date_format = site.cayman-blog.date_format | default: "%b %-d, %Y" %}
           {{ page.date | date: date_format }}
         </time>
         {% assign page_author = page.author | default: site.author | default: nil | escape %}
         {% if page_author %}
-          • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page_author }}</span></span>
+          &middot; <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page_author }}</span></span>
         {% endif %}
-        </h2>
+        </p>
       {% endif %}
-      <!-- End: Post tagline -->
     </section>
+    {% endunless %}
 
     <section class="main-content">
 
       {{ content }}
 
       <footer class="site-footer">
-        <!-- SVG icons from https://iconmonstr.com -->
-
-        <!-- Github icon -->
-        <span class="my-span-icon">
-          <a href="{{ site.github.owner_url }}" aria-label="{{ site.github.owner_name }}'s GitHub" title="{{ site.github.owner_name }}'s GitHub">
-            <svg class="my-svg-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-          </a>
-        </span>
-
-        <!-- Twitter icon -->
-        <span class="my-span-icon">
-          <a href="https://twitter.com/{{ site.twitter.username }}" aria-label="{{ site.github.owner_name }}'s Twitter" title="{{ site.github.owner_name }}'s Twitter">
-            <svg class="my-svg-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm6.066 9.645c.183 4.04-2.83 8.544-8.164 8.544-1.622 0-3.131-.476-4.402-1.291 1.524.18 3.045-.244 4.252-1.189-1.256-.023-2.317-.854-2.684-1.995.451.086.895.061 1.298-.049-1.381-.278-2.335-1.522-2.304-2.853.388.215.83.344 1.301.359-1.279-.855-1.641-2.544-.889-3.835 1.416 1.738 3.533 2.881 5.92 3.001-.419-1.796.944-3.527 2.799-3.527.825 0 1.572.349 2.096.907.654-.128 1.27-.368 1.824-.697-.215.671-.67 1.233-1.263 1.589.581-.07 1.135-.224 1.649-.453-.384.578-.87 1.084-1.433 1.489z"/></svg>
-          </a>
-        </span>
-
-        <!-- RSS icon -->
-        {% if site.gems contains "jekyll-feed" %}
-          <span class="my-span-icon">
-            <a href="{{ "/feed.xml" | relative_url }}" aria-label="RSS feed" title="{{ site.github.owner_name }}'s RSS feed">
-              <svg class="my-svg-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm-3.374 17c-.897 0-1.626-.727-1.626-1.624s.729-1.624 1.626-1.624 1.626.727 1.626 1.624-.729 1.624-1.626 1.624zm3.885 0c-.03-3.022-2.485-5.474-5.511-5.504v-2.406c4.361.03 7.889 3.555 7.92 7.91h-2.409zm4.081 0c-.016-5.297-4.303-9.571-9.592-9.594v-2.406c6.623.023 11.985 5.384 12 12h-2.408z"/></svg>
-            </a>
-          </span>
-        {% endif %}
-        <!-- Contact icon -->
-        {% assign about_page = site.pages | where: "path", "about.md" | first %}
-        {% if about_page.title %}
-          <span class="my-span-icon">
-            <a href="{{ about_page.url | relative_url }}" aria-label="Contact" title="Contact {{ site.github.owner_name }}">
-              <svg class="my-svg-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 .02c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm6.99 6.98l-6.99 5.666-6.991-5.666h13.981zm.01 10h-14v-8.505l7 5.673 7-5.672v8.504z"/></svg>
-            </a>
-          </span>
-        {% endif %}
-
+        <p class="footer-text">&copy; {{ 'now' | date: "%Y" }} {{ site.author }}. All rights reserved.</p>
       </footer>
     </section>
 
     {% if site.google_analytics %}
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118378167-1"></script>
-        <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'UA-118378167-1');
-        </script>
-
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118378167-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-118378167-1');
+    </script>
     {% endif %}
   </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,11 +4,14 @@ layout: default
 
 <div>
 
+  <div class="home-intro">
+    <h1 class="home-title">Hey, I'm Chaitya</h1>
+    <p class="home-description">{{ site.description }}</p>
+  </div>
+
   {{ content }}
 
   <h2>Latest Posts</h2>
-
-  <div>&nbsp;</div>
 
   <ul class="post-list">
     {% for post in site.posts %}
@@ -21,7 +24,7 @@ layout: default
           <a class="post-link" href="{{ post.url | relative_url }}" title="{{ post.title }}">{{ post.title | escape }}</a>
         </h2>
 
-        <span>{{ post.excerpt | markdownify | truncatewords: 30 }}</span>
+        <div class="post-excerpt">{{ post.excerpt | markdownify | strip_html | truncatewords: 40 }}</div>
 
       </li>
     {% endfor %}

--- a/_sass/blog.scss
+++ b/_sass/blog.scss
@@ -1,36 +1,21 @@
 @charset "utf-8";
 
-// Define defaults for each variable.
-
 $base-font-size:   16px !default;
 $base-font-weight: 400 !default;
 $small-font-size:  $base-font-size * 0.875 !default;
-$base-line-height: 1.5 !default;
+$base-line-height: 1.7 !default;
 
 $spacing-unit:     30px !default;
-
-$text-color:       $section-headings-color !default;
-$background-color: #fdfdfd !default;
-$brand-color:      #2a7ae2 !default;
 
 $grey-color:       #828282 !default;
 $grey-color-light: lighten($grey-color, 40%) !default;
 $grey-color-dark:  darken($grey-color, 25%) !default;
 
-// Width of the content area
-//$content-width:    800px !default;
-$navbar-width:    54em !default;
+$navbar-width:    42rem !default;
 
 $on-palm:          38em !default;
-$on-laptop:        54em !default;
+$on-laptop:        42rem !default;
 
-// Use media queries like this:
-// @include media-query($on-palm) {
-//   .wrapper {
-//     padding-right: $spacing-unit / 2;
-//     padding-left: $spacing-unit / 2;
-//   }
-// }
 @mixin media-query($device) {
   @media screen and (max-width: $device) {
     @content;
@@ -41,7 +26,6 @@ $on-laptop:        54em !default;
   font-size: $base-font-size * $ratio;
 }
 
-// Import partials.
 @import
   "blog/base",
   "blog/layout"

--- a/_sass/blog/_base.scss
+++ b/_sass/blog/_base.scss
@@ -2,23 +2,17 @@
  * Wrapper
  */
 .wrapper {
-  max-width: -webkit-calc(#{$navbar-width} - (#{$spacing-unit} * 2));
-  max-width:         calc(#{$navbar-width} - (#{$spacing-unit} * 2));
+  max-width: 42rem;
   margin-right: auto;
   margin-left: auto;
-  padding-right: $spacing-unit;
-  padding-left: $spacing-unit;
-  @extend %clearfix;
+  padding-right: 1.5rem;
+  padding-left: 1.5rem;
 
-  @include media-query($on-laptop) {
-    max-width: -webkit-calc(#{$navbar-width} - (#{$spacing-unit}));
-    max-width:         calc(#{$navbar-width} - (#{$spacing-unit}));
-    padding-right: $spacing-unit / 2;
-    padding-left: $spacing-unit / 2;
+  @include media-query($on-palm) {
+    padding-right: 1.25rem;
+    padding-left: 1.25rem;
   }
 }
-
-
 
 /**
  * Clearfix

--- a/_sass/blog/_layout.scss
+++ b/_sass/blog/_layout.scss
@@ -2,108 +2,163 @@
  * Site header
  */
 .site-header {
-  border-bottom: 1px solid $grey-color-light;
-  min-height: $spacing-unit * 1.865;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: var(--nav-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+}
 
-  // Positioning context for the mobile navigation icon
-  position: relative;
+.site-header .wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 3.5rem;
 }
 
 .site-title {
-  @include relative-font-size(1.4);
-  font-weight: 300;
-  line-height: $base-line-height * $base-font-size * 2.25;
-  letter-spacing: -1px;
-  margin-bottom: 0;
-  float: left;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   text-decoration: none;
+  color: var(--heading);
+  transition: color 0.2s ease;
+  white-space: nowrap;
 
-  &,
   &:visited,
   &:hover {
-    color: $text-color;
+    color: var(--heading);
     text-decoration: none;
   }
 }
 
 .site-nav {
-  float: right;
-  line-height: $base-line-height * $base-font-size * 2.25;
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
 
   .nav-trigger {
-      display: none;
-  }
-
-  .menu-icon {
     display: none;
   }
 
-  .page-link {
-    color: $text-color;
-    line-height: $base-line-height;
-
-    // Gaps between nav items, but not on the last one
-    &:not(:last-child) {
-      margin-right: 20px;
-    }
+  .menu-icon-label {
+    display: none;
   }
 
-  @include media-query($on-palm) {
-    position: absolute;
-    top: 9px;
-    right: $spacing-unit / 2;
-    background-color: $background-color;
-    border: 1px solid $grey-color-light;
-    border-radius: 5px;
-    text-align: right;
+  .mobile-menu {
+    display: none;
+  }
+}
 
-    label[for="nav-trigger"] {
-      display: block;
-      float: right;
-      width: 36px;
-      height: 36px;
-      z-index: 2;
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+
+  .page-link {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 450;
+    text-decoration: none;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: var(--heading);
+      text-decoration: none;
+    }
+  }
+}
+
+.nav-icons {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.social-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: var(--toggle-bg);
+    text-decoration: none;
+  }
+
+  svg {
+    width: 18px;
+    height: 18px;
+    fill: var(--text-muted);
+    transition: fill 0.2s ease;
+  }
+
+  &:hover svg {
+    fill: var(--heading);
+  }
+}
+
+/* Mobile nav */
+@include media-query($on-palm) {
+  .nav-links {
+    display: none;
+  }
+
+  .site-nav {
+    gap: 0.5rem;
+
+    .menu-icon-label {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
       cursor: pointer;
-    }
+      border-radius: 0.375rem;
 
-    .menu-icon {
-      display: block;
-      float: right;
-      width: 36px;
-      height: 26px;
-      line-height: 0;
-      padding-top: 10px;
-      text-align: center;
+      &:hover {
+        background-color: var(--toggle-bg);
+      }
 
-      > svg path {
-        fill: $grey-color-dark;
+      svg path {
+        fill: var(--text-secondary);
       }
     }
 
-    input ~ .trigger {
-      clear: both;
+    .nav-trigger:checked ~ .mobile-menu {
+      display: flex;
+    }
+
+    .mobile-menu {
       display: none;
-    }
+      position: absolute;
+      top: 3.5rem;
+      left: 0;
+      right: 0;
+      flex-direction: column;
+      background-color: var(--bg);
+      border-bottom: 1px solid var(--border);
+      padding: 0.5rem 1.25rem 1rem;
+      transition: background-color 0.3s ease;
 
-    input:checked ~ .trigger {
-      display: block;
-      padding-bottom: 5px;
-    }
+      .page-link {
+        display: block;
+        padding: 0.5rem 0;
+        color: var(--text-secondary);
+        font-size: 0.9rem;
+        text-decoration: none;
 
-    .trigger {
-      padding-top: 20px;
-    }
-    .page-link {
-      display: block;
-      padding: 10px 10px;
-
-      &:last-child {
-        margin-bottom: 10px;
+        &:hover {
+          color: var(--heading);
+        }
       }
-      margin-right: 10px;
-      margin-left: 10px;
     }
-
   }
 }
 
@@ -113,30 +168,99 @@
 .post-list {
   margin-left: 0;
   list-style: none;
+  padding: 0;
 
   > li {
-    margin-bottom: $spacing-unit * 1.5;
+    margin-bottom: 2.5rem;
+    padding-bottom: 2.5rem;
+    border-bottom: 1px solid var(--border);
+    transition: border-color 0.3s ease;
+
+    &:last-child {
+      border-bottom: none;
+    }
   }
 
   > li > h2 {
-    margin-top: 0rem;
-    margin-bottom: 0.4rem;
-  }
-}
-
-@include media-query($on-palm) {
-  .post-list {
-    -webkit-margin-end: 10px;
-    -webkit-padding-start: 10px;
+    margin-top: 0;
+    margin-bottom: 0.25rem;
   }
 }
 
 .post-meta {
-  font-size: $small-font-size;
-  color: $grey-color;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  transition: color 0.3s ease;
 }
 
 .post-link {
   display: block;
-  @include relative-font-size(1.5);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--heading);
+  letter-spacing: -0.01em;
+  transition: color 0.2s ease;
+  text-decoration: none;
+
+  &:hover {
+    color: var(--link);
+    text-decoration: none;
+  }
+}
+
+.post-excerpt {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin-top: 0.5rem;
+  transition: color 0.3s ease;
+}
+
+/**
+ * Theme toggle
+ */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: none;
+  border-radius: 0.375rem;
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  flex-shrink: 0;
+
+  &:hover {
+    background: var(--toggle-bg);
+  }
+
+  svg {
+    width: 18px;
+    height: 18px;
+    fill: var(--text-muted);
+    transition: fill 0.2s ease;
+  }
+
+  &:hover svg {
+    fill: var(--heading);
+  }
+
+  .icon-sun {
+    display: none;
+  }
+  .icon-moon {
+    display: block;
+  }
+}
+
+.dark .theme-toggle {
+  .icon-sun {
+    display: block;
+  }
+  .icon-moon {
+    display: none;
+  }
 }

--- a/_sass/jekyll-theme-cayman-blog.scss
+++ b/_sass/jekyll-theme-cayman-blog.scss
@@ -1,6 +1,6 @@
 @import "normalize";
-@import "rouge-github";
 @import "variables";
+@import "rouge-github";
 @import "blog";
 
 @mixin large {
@@ -25,208 +25,152 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   padding: 0;
   margin: 0;
-  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 16px;
-  line-height: 1.5;
-  color: $body-text-color;
+  line-height: 1.7;
+  color: var(--text);
+  background-color: var(--bg);
+  transition: background-color 0.3s ease, color 0.3s ease;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 a {
-  color: $body-link-color;
+  color: var(--link);
   text-decoration: none;
+  text-underline-offset: 3px;
+  transition: color 0.2s ease;
 
   &:hover {
+    color: var(--link-hover);
     text-decoration: underline;
+    text-decoration-thickness: 1px;
   }
 }
 
-.btn {
-  display: inline-block;
-  margin-bottom: 1rem;
-  color: rgba(255, 255, 255, 0.7);
-  background-color: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.2);
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 0.3rem;
-  transition: color 0.2s, background-color 0.2s, border-color 0.2s;
-
-  &:hover {
-    color: rgba(255, 255, 255, 0.8);
-    text-decoration: none;
-    background-color: rgba(255, 255, 255, 0.2);
-    border-color: rgba(255, 255, 255, 0.3);
-  }
-
-  + .btn {
-    margin-left: 1rem;
-  }
-
-  @include large {
-    padding: 0.75rem 1rem;
-  }
-
-  @include medium {
-    padding: 0.6rem 0.9rem;
-    font-size: 0.9rem;
-  }
-
-  @include small {
-    display: block;
-    width: 100%;
-    padding: 0.75rem;
-    font-size: 0.9rem;
-
-    + .btn {
-      margin-top: 1rem;
-      margin-left: 0;
-    }
-  }
-}
-
+// Page header — now minimal, no giant green banner
 .page-header {
-  color: $header-heading-color;
-  text-align: center;
-  background-color: #27ae60;
-  @include large {
-    padding: 5rem 6rem;
-  }
-
-  @include medium {
-    padding: 3rem 4rem;
-  }
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 1rem;
+  border-bottom: 1px solid var(--border);
+  transition: border-color 0.3s ease;
 
   @include small {
-    padding: 2rem 1rem;
+    padding: 2rem 1.25rem 0.75rem;
   }
 }
 
 .project-name {
-  margin-top: 0;
-  margin-bottom: 0.1rem;
-
-  @include large {
-    font-size: 3.25rem;
-  }
-
-  @include medium {
-    font-size: 2.25rem;
-  }
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--heading);
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  transition: color 0.3s ease;
 
   @include small {
-    font-size: 1.75rem;
+    font-size: 1.4rem;
   }
 }
 
 .project-tagline {
-  margin-bottom: 2rem;
-  font-weight: normal;
-  opacity: 0.7;
-
-  @include large {
-    font-size: 1.25rem;
-  }
-
-  @include medium {
-    font-size: 1.15rem;
-  }
+  margin: 0 0 0.5rem;
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  transition: color 0.3s ease;
 
   @include small {
-    font-size: 1rem;
+    font-size: 0.9rem;
   }
 }
 
 .project-date {
-  margin-bottom: 0rem;
-  font-weight: normal;
-  opacity: 0.7;
-  font-style: italic;
-
-  @include large {
-    font-size: 1.0rem;
-  }
-
-  @include medium {
-    font-size: 0.95rem;
-  }
-
-  @include small {
-    font-size: 0.75rem;
-  }
+  margin: 0;
+  font-weight: 400;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-style: normal;
+  transition: color 0.3s ease;
 }
 
+// Main content
 .main-content {
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
   word-wrap: break-word;
+
+  @include small {
+    padding: 1.5rem 1.25rem;
+  }
 
   :first-child {
     margin-top: 0;
   }
 
-  @include large {
-    max-width: 64rem;
-    padding: 3rem 6rem;
-    margin: 0 auto;
-    font-size: 1.1rem;
-  }
-
-  @include medium {
-    padding: 3rem 4rem;
-    font-size: 1.1rem;
-  }
-
-  @include small {
-    padding: 2rem 1rem;
-    font-size: 1rem;
-  }
-
   img {
     max-width: 100%;
+    border-radius: 0.5rem;
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-    font-weight: normal;
-    color: $section-headings-color;
+  h1, h2, h3, h4, h5, h6 {
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    font-weight: 600;
+    color: var(--heading);
+    letter-spacing: -0.01em;
+    line-height: 1.3;
+    transition: color 0.3s ease;
   }
+
+  h1 { font-size: 1.75rem; }
+  h2 { font-size: 1.4rem; }
+  h3 { font-size: 1.15rem; }
 
   p {
-    margin-bottom: 1em;
+    margin-bottom: 1.25em;
+    color: var(--text);
+    transition: color 0.3s ease;
   }
 
   code {
-    padding: 2px 4px;
-    font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    font-size: 0.9rem;
-    color: $code-text-color;
-    background-color: $code-bg-color;
-    border-radius: 0.3rem;
+    padding: 0.15em 0.4em;
+    font-family: "JetBrains Mono", "Fira Code", "SF Mono", Consolas, monospace;
+    font-size: 0.85em;
+    color: var(--inline-code-text);
+    background-color: var(--inline-code-bg);
+    border-radius: 0.25rem;
+    transition: background-color 0.3s ease, color 0.3s ease;
   }
 
   pre {
-    padding: 0.8rem;
+    padding: 1.25rem;
     margin-top: 0;
-    margin-bottom: 1rem;
-    font: 1rem Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    color: $code-text-color;
+    margin-bottom: 1.5rem;
+    font: 0.875rem "JetBrains Mono", "Fira Code", "SF Mono", Consolas, monospace;
+    color: var(--code-text);
     word-wrap: normal;
-    background-color: $code-bg-color;
-    border: solid 1px $border-color;
-    border-radius: 0.3rem;
+    background-color: var(--code-bg);
+    border: none;
+    border-radius: 0.5rem;
+    transition: background-color 0.3s ease;
 
     > code {
       padding: 0;
       margin: 0;
-      font-size: 0.9rem;
-      color: $code-text-color;
+      font-size: 0.875rem;
+      color: var(--code-text);
       word-break: normal;
       white-space: pre;
       background: transparent;
@@ -235,7 +179,7 @@ a {
   }
 
   .highlight {
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
 
     pre {
       margin-bottom: 0;
@@ -245,11 +189,11 @@ a {
 
   .highlight pre,
   pre {
-    padding: 0.8rem;
+    padding: 1.25rem;
     overflow: auto;
-    font-size: 0.9rem;
-    line-height: 1.45;
-    border-radius: 0.3rem;
+    font-size: 0.875rem;
+    line-height: 1.6;
+    border-radius: 0.5rem;
     -webkit-overflow-scrolling: touch;
   }
 
@@ -271,16 +215,23 @@ a {
     }
   }
 
-  ul,
-  ol {
+  ul, ol {
     margin-top: 0;
+    color: var(--text);
+    transition: color 0.3s ease;
+  }
+
+  li {
+    margin-bottom: 0.25em;
   }
 
   blockquote {
-    padding: 0 1rem;
+    padding: 0 1.25rem;
     margin-left: 0;
-    color: $blockquote-text-color;
-    border-left: 0.3rem solid $border-color;
+    margin-right: 0;
+    color: var(--blockquote-text);
+    border-left: 3px solid var(--blockquote-border);
+    transition: color 0.3s ease, border-color 0.3s ease;
 
     > :first-child {
       margin-top: 0;
@@ -296,17 +247,22 @@ a {
     width: 100%;
     overflow: auto;
     word-break: normal;
-    word-break: keep-all; // For Firefox to horizontally scroll wider tables.
     -webkit-overflow-scrolling: touch;
+    border-collapse: collapse;
 
     th {
-      font-weight: bold;
+      font-weight: 600;
+      color: var(--heading);
     }
 
-    th,
-    td {
-      padding: 0.5rem 1rem;
-      border: 1px solid $table-border-color;
+    th, td {
+      padding: 0.625rem 1rem;
+      border: 1px solid var(--border);
+      transition: border-color 0.3s ease;
+    }
+
+    tr:nth-child(even) {
+      background-color: var(--bg-secondary);
     }
   }
 
@@ -317,7 +273,7 @@ a {
       padding: 0;
       margin-top: 1rem;
       font-size: 1rem;
-      font-weight: bold;
+      font-weight: 600;
     }
 
     dd {
@@ -327,106 +283,70 @@ a {
   }
 
   hr {
-    height: 2px;
+    height: 1px;
     padding: 0;
-    margin: 1rem 0;
-    background-color: $hr-border-color;
+    margin: 2rem 0;
+    background-color: var(--border);
     border: 0;
+    transition: background-color 0.3s ease;
+  }
+
+  // Details/summary styling
+  details {
+    margin-bottom: 1.25em;
+
+    summary {
+      cursor: pointer;
+      font-weight: 500;
+      color: var(--heading);
+
+      &:hover {
+        color: var(--link);
+      }
+    }
   }
 }
 
+// Footer
 .site-footer {
   padding-top: 2rem;
-  margin-top: 2rem;
-  border-top: solid 1px $hr-border-color;
+  margin-top: 3rem;
+  border-top: 1px solid var(--border);
+  text-align: center;
+  transition: border-color 0.3s ease;
 
-  @include large {
-    font-size: 1rem;
-  }
-
-  @include medium {
-    font-size: 1rem;
-  }
-
-  @include small {
-    font-size: 0.9rem;
-    margin-bottom: 0.5rem;
+  .footer-text {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    transition: color 0.3s ease;
   }
 }
 
-.site-footer-owner {
-  display: block;
-  font-weight: bold;
-}
+// Home intro
+.home-intro {
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border);
+  transition: border-color 0.3s ease;
 
-.site-footer-credits {
-  color: $blockquote-text-color;
-}
-
-.site-footer {
-
-  @include large {
-  }
-
-  @include medium {
-  }
-
-  @include small {
-  }
-
-  .my-span-icon {
-
-    a {
-    	text-decoration: none;
-    }
-    a:hover {
-      text-decoration: none;
-    }
-
-    @include large {
-      padding: 0px 5px 0px 5px;
-    }
-
-    @include medium {
-      //font-size: 1rem;
-      padding: 0px 10px 10px 10px;
-    }
+  .home-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--heading);
+    margin: 0 0 0.5rem;
+    letter-spacing: -0.02em;
+    transition: color 0.3s ease;
 
     @include small {
-      padding: 0px 10px 10px 10px;
+      font-size: 1.4rem;
     }
   }
 
-  .my-svg-icon {
-
-    color: $body-text-color; // IE8
-    fill: $body-text-color; // IE8
-    width: 24px;
-    height: 24px;
-
-    &:hover {
-      text-decoration: none;
-      color: $section-headings-color; // IE8
-      fill: $section-headings-color;
-      transform: scale(1.25);
-      transition: color .5s, transform .2s ease-out
-    }
-
-    @include large {
-      width: 28px;
-      height: 28px;
-    }
-
-    @include medium {
-      width: 32px;
-      height: 32px;
-    }
-
-    @include small {
-      width: 36px;
-      height: 36px;
-    }
-
-  } // social-icons
-
+  .home-description {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.6;
+    transition: color 0.3s ease;
+  }
 }

--- a/_sass/rouge-github.scss
+++ b/_sass/rouge-github.scss
@@ -1,209 +1,67 @@
+// Dark code blocks for both light and dark mode
 .highlight table td { padding: 5px; }
 .highlight table pre { margin: 0; }
-.highlight .cm {
-  color: #999988;
-  font-style: italic;
-}
-.highlight .cp {
-  color: #999999;
-  font-weight: bold;
-}
-.highlight .c1 {
-  color: #999988;
-  font-style: italic;
-}
-.highlight .cs {
-  color: #999999;
-  font-weight: bold;
-  font-style: italic;
-}
-.highlight .c, .highlight .cd {
-  color: #999988;
-  font-style: italic;
-}
-.highlight .err {
-  color: #a61717;
-  background-color: #e3d2d2;
-}
-.highlight .gd {
-  color: #000000;
-  background-color: #ffdddd;
-}
-.highlight .ge {
-  color: #000000;
-  font-style: italic;
-}
-.highlight .gr {
-  color: #aa0000;
-}
-.highlight .gh {
-  color: #999999;
-}
-.highlight .gi {
-  color: #000000;
-  background-color: #ddffdd;
-}
-.highlight .go {
-  color: #888888;
-}
-.highlight .gp {
-  color: #555555;
-}
-.highlight .gs {
-  font-weight: bold;
-}
-.highlight .gu {
-  color: #aaaaaa;
-}
-.highlight .gt {
-  color: #aa0000;
-}
-.highlight .kc {
-  color: #000000;
-  font-weight: bold;
-}
-.highlight .kd {
-  color: #000000;
-  font-weight: bold;
-}
-.highlight .kn {
-  color: #000000;
-  font-weight: bold;
-}
-.highlight .kp {
-  color: #000000;
-  font-weight: bold;
-}
-.highlight .kr {
-  color: #000000;
-  font-weight: bold;
-}
-.highlight .kt {
-  color: #445588;
-  font-weight: bold;
-}
-.highlight .k, .highlight .kv {
-  color: #000000;
-  font-weight: bold;
-}
-.highlight .mf {
-  color: #009999;
-}
-.highlight .mh {
-  color: #009999;
-}
-.highlight .il {
-  color: #009999;
-}
-.highlight .mi {
-  color: #009999;
-}
-.highlight .mo {
-  color: #009999;
-}
-.highlight .m, .highlight .mb, .highlight .mx {
-  color: #009999;
-}
-.highlight .sb {
-  color: #d14;
-}
-.highlight .sc {
-  color: #d14;
-}
-.highlight .sd {
-  color: #d14;
-}
-.highlight .s2 {
-  color: #d14;
-}
-.highlight .se {
-  color: #d14;
-}
-.highlight .sh {
-  color: #d14;
-}
-.highlight .si {
-  color: #d14;
-}
-.highlight .sx {
-  color: #d14;
-}
-.highlight .sr {
-  color: #009926;
-}
-.highlight .s1 {
-  color: #d14;
-}
-.highlight .ss {
-  color: #990073;
-}
-.highlight .s {
-  color: #d14;
-}
-.highlight .na {
-  color: #008080;
-}
-.highlight .bp {
-  color: #999999;
-}
-.highlight .nb {
-  color: #0086B3;
-}
-.highlight .nc {
-  color: #445588;
-  font-weight: bold;
-}
-.highlight .no {
-  color: #008080;
-}
-.highlight .nd {
-  color: #3c5d5d;
-  font-weight: bold;
-}
-.highlight .ni {
-  color: #800080;
-}
-.highlight .ne {
-  color: #990000;
-  font-weight: bold;
-}
-.highlight .nf {
-  color: #990000;
-  font-weight: bold;
-}
-.highlight .nl {
-  color: #990000;
-  font-weight: bold;
-}
-.highlight .nn {
-  color: #555555;
-}
-.highlight .nt {
-  color: #000080;
-}
-.highlight .vc {
-  color: #008080;
-}
-.highlight .vg {
-  color: #008080;
-}
-.highlight .vi {
-  color: #008080;
-}
-.highlight .nv {
-  color: #008080;
-}
-.highlight .ow {
-  color: #000000;
-  font-weight: bold;
-}
-.highlight .o {
-  color: #000000;
-  font-weight: bold;
-}
-.highlight .w {
-  color: #bbbbbb;
-}
+.highlight .cm { color: #6c7086; font-style: italic; }
+.highlight .cp { color: #f5c2e7; }
+.highlight .c1 { color: #6c7086; font-style: italic; }
+.highlight .cs { color: #6c7086; font-style: italic; }
+.highlight .c, .highlight .cd { color: #6c7086; font-style: italic; }
+.highlight .err { color: #f38ba8; }
+.highlight .gd { color: #f38ba8; background-color: rgba(243, 139, 168, 0.1); }
+.highlight .ge { font-style: italic; }
+.highlight .gr { color: #f38ba8; }
+.highlight .gh { color: #cdd6f4; font-weight: bold; }
+.highlight .gi { color: #a6e3a1; background-color: rgba(166, 227, 161, 0.1); }
+.highlight .go { color: #a6adc8; }
+.highlight .gp { color: #94e2d5; }
+.highlight .gs { font-weight: bold; }
+.highlight .gu { color: #94e2d5; font-weight: bold; }
+.highlight .gt { color: #f38ba8; }
+.highlight .kc { color: #cba6f7; font-weight: bold; }
+.highlight .kd { color: #cba6f7; }
+.highlight .kn { color: #94e2d5; }
+.highlight .kp { color: #cba6f7; }
+.highlight .kr { color: #cba6f7; font-weight: bold; }
+.highlight .kt { color: #f9e2af; }
+.highlight .k, .highlight .kv { color: #cba6f7; }
+.highlight .mf { color: #fab387; }
+.highlight .mh { color: #fab387; }
+.highlight .il { color: #fab387; }
+.highlight .mi { color: #fab387; }
+.highlight .mo { color: #fab387; }
+.highlight .m, .highlight .mb, .highlight .mx { color: #fab387; }
+.highlight .sb { color: #a6e3a1; }
+.highlight .sc { color: #a6e3a1; }
+.highlight .sd { color: #6c7086; font-style: italic; }
+.highlight .s2 { color: #a6e3a1; }
+.highlight .se { color: #fab387; }
+.highlight .sh { color: #a6e3a1; }
+.highlight .si { color: #fab387; }
+.highlight .sx { color: #a6e3a1; }
+.highlight .sr { color: #f5c2e7; }
+.highlight .s1 { color: #a6e3a1; }
+.highlight .ss { color: #f5c2e7; }
+.highlight .s { color: #a6e3a1; }
+.highlight .na { color: #89b4fa; }
+.highlight .bp { color: #f5c2e7; }
+.highlight .nb { color: #f5c2e7; }
+.highlight .nc { color: #f9e2af; font-weight: bold; }
+.highlight .no { color: #f9e2af; }
+.highlight .nd { color: #89dceb; font-weight: bold; }
+.highlight .ni { color: #cdd6f4; }
+.highlight .ne { color: #fab387; font-weight: bold; }
+.highlight .nf { color: #89b4fa; }
+.highlight .nl { color: #f9e2af; }
+.highlight .nn { color: #f9e2af; }
+.highlight .nt { color: #89b4fa; }
+.highlight .vc { color: #cdd6f4; }
+.highlight .vg { color: #cdd6f4; }
+.highlight .vi { color: #cdd6f4; }
+.highlight .nv { color: #cdd6f4; }
+.highlight .ow { color: #94e2d5; font-weight: bold; }
+.highlight .o { color: #94e2d5; }
+.highlight .w { color: #a6adc8; }
 .highlight {
-  background-color: #f8f8f8;
+  background-color: var(--code-bg);
+  border-radius: 0.5rem;
 }

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -2,22 +2,50 @@
 $large-breakpoint: 64em !default;
 $medium-breakpoint: 42em !default;
 
-// Headers
-$header-heading-color: #fff !default;
-$header-bg-color: #159957 !default;
-$header-bg-color-secondary: #155799 !default;
+// Light mode (defaults)
+:root {
+  --bg: #ffffff;
+  --bg-secondary: #f9fafb;
+  --text: #1a1a2e;
+  --text-secondary: #6b7280;
+  --text-muted: #9ca3af;
+  --link: #2563eb;
+  --link-hover: #1d4ed8;
+  --heading: #111827;
+  --border: #e5e7eb;
+  --code-bg: #1e1e2e;
+  --code-text: #cdd6f4;
+  --inline-code-bg: #f3f4f6;
+  --inline-code-text: #e11d48;
+  --blockquote-border: #d1d5db;
+  --blockquote-text: #6b7280;
+  --nav-bg: rgba(255, 255, 255, 0.85);
+  --footer-text: #9ca3af;
+  --card-shadow: 0 1px 3px rgba(0,0,0,0.04);
+  --toggle-bg: #f3f4f6;
+  --toggle-hover: #e5e7eb;
+}
 
-// Text
-$section-headings-color: #159957 !default;
-$body-text-color: #606c71 !default;
-$body-link-color: #1e6bb8 !default;
-$blockquote-text-color: #819198 !default;
-
-// Code
-$code-bg-color: #f3f6fa !default;
-$code-text-color: #567482 !default;
-
-// Borders
-$border-color: #dce6f0 !default;
-$table-border-color: #e9ebec !default;
-$hr-border-color: #eff0f1 !default;
+// Dark mode
+:root.dark {
+  --bg: #0f0f17;
+  --bg-secondary: #1a1a2e;
+  --text: #e4e4e7;
+  --text-secondary: #a1a1aa;
+  --text-muted: #71717a;
+  --link: #60a5fa;
+  --link-hover: #93bbfd;
+  --heading: #f4f4f5;
+  --border: #27272a;
+  --code-bg: #1a1a2e;
+  --code-text: #cdd6f4;
+  --inline-code-bg: #27272a;
+  --inline-code-text: #f472b6;
+  --blockquote-border: #3f3f46;
+  --blockquote-text: #a1a1aa;
+  --nav-bg: rgba(15, 15, 23, 0.85);
+  --footer-text: #71717a;
+  --card-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  --toggle-bg: #27272a;
+  --toggle-hover: #3f3f46;
+}

--- a/jekyll-theme-cayman-blog.gemspec
+++ b/jekyll-theme-cayman-blog.gemspec
@@ -9,7 +9,15 @@ Gem::Specification.new do |s|
   s.homepage      = "https://github.com/lorepirri/cayman-blog"
   s.summary       = "Cayman Blog Theme is a clean, responsive blogging theme for Jekyll and GitHub Pages, with social/SEO features. Based on Cayman theme."
 
-  s.files         = `git ls-files -z`.split("\x0").select do |f|
+  tracked_files = if File.directory?(".git")
+    `git ls-files -z`.split("\x0")
+  else
+    Dir.glob("{_includes,_layouts,_sass,assets}/**/*", File::FNM_DOTMATCH).reject do |f|
+      File.directory?(f)
+    end + Dir.glob("{LICENSE,README,index,about,contact,404}*", File::FNM_CASEFOLD)
+  end
+
+  s.files         = tracked_files.select do |f|
     f.match(%r{^((_includes|_layouts|_sass|assets)/|(LICENSE|README|index|about|contact|404)((\.(txt|md|markdown)|$)))}i)
   end
 


### PR DESCRIPTION
## Summary
- Replaced the green banner header with a clean, minimal single-column layout (42rem max-width) inspired by modern dev blogs like overreacted.io and leerob.io
- Added light/dark mode toggle with localStorage persistence, system preference fallback, and FOUC prevention
- Moved social links (GitHub, X/Twitter, LinkedIn) into a sticky glass-blur nav bar
- Switched typography to Inter + JetBrains Mono with improved spacing and line heights
- Always-dark code blocks using Catppuccin Mocha color scheme
- Friendly homepage intro instead of redundant title header
- Added Dockerfile for containerized local development

## Test plan
- [ ] Verify light and dark mode toggle works and persists across page refreshes
- [ ] Check system preference fallback when no theme is saved
- [ ] Verify nav bar layout on mobile (hamburger menu) and desktop
- [ ] Check social icons (GitHub, X, LinkedIn) link to correct profiles
- [ ] Verify code blocks render with dark theme in both modes
- [ ] Test post pages, about page, and home page layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)